### PR TITLE
Load extras sequentially to respect module dependencies

### DIFF
--- a/nicegui_highcharts/highchart.js
+++ b/nicegui_highcharts/highchart.js
@@ -7,7 +7,9 @@ export default {
     if (this.extras) {
       await loadMore();
     }
-    await Promise.all(this.extras.map((extra) => loadModule(extra)));
+    for (const extra of this.extras) {
+      await loadModule(extra);
+    }
     convertDynamicProperties(this.options, true);
     this.seriesCount = this.options.series ? this.options.series.length : 0;
     this.options.plotOptions = this.options.plotOptions ?? {};


### PR DESCRIPTION
**Fixes #26:**
Load Highcharts extras sequentially instead of in parallel to fix race condition where dependent modules (e.g., `organization`) could initialize before their dependencies (e.g., `sankey`) were registered.

**Test:**
Create a chart and reload repeatedly:
```py
ui.highchart({}, extras=['sankey', 'organization'])
```
The `TypeError: Cannot read properties of undefined (reading 'prototype')` error should no longer occur
