### PR TITLE
Fix adding and removing chart series

### DIFF
--- a/nicegui_highcharts/highchart.js
+++ b/nicegui_highcharts/highchart.js
@@ -11,7 +11,6 @@ export default {
       await loadModule(extra);
     }
     convertDynamicProperties(this.options, true);
-    this.seriesCount = this.options.series ? this.options.series.length : 0;
     this.options.plotOptions = this.options.plotOptions ?? {};
     this.options.plotOptions.series = this.options.plotOptions.series ?? {};
     this.options.plotOptions.series.point = this.options.plotOptions.series.point ?? {};
@@ -44,16 +43,8 @@ export default {
   methods: {
     update_chart() {
       if (this.chart) {
-        while (this.seriesCount > this.options.series.length) {
-          this.chart.series[0].remove();
-          this.seriesCount--;
-        }
-        while (this.seriesCount < this.options.series.length) {
-          this.chart.addSeries({}, false);
-          this.seriesCount++;
-        }
         convertDynamicProperties(this.options, true);
-        this.chart.update(this.options);
+        this.chart.update(this.options, true, true);
       }
     },
     destroyChart() {

--- a/uv.lock
+++ b/uv.lock
@@ -785,7 +785,7 @@ wheels = [
 
 [[package]]
 name = "nicegui-highcharts"
-version = "3.1.0"
+version = "3.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "nicegui" },


### PR DESCRIPTION
Fixes #1

## Problem

`update_chart()` tried to keep the chart in sync with `options.series` using a series-count heuristic: while there are too many series, remove `chart.series[0]`; while there are too few, add an empty series `{}`; then call `chart.update(options)`. Since `chart.update()` matches series by index (or by `id`, which the empty placeholder series never had), this confused Highcharts as soon as series were added or removed — the chart would show wrong data after a few toggles (see the reproductions in #1).

## Solution

Highcharts has a built-in mechanism for exactly this: [one-to-one updating](https://api.highcharts.com/class-reference/Highcharts.Chart#update), the third parameter of `chart.update()`. With `oneToOne = true`, Highcharts adds and removes series itself so the chart matches `options.series` declaratively. The whole `seriesCount` bookkeeping becomes obsolete:

```js
update_chart() {
  if (this.chart) {
    convertDynamicProperties(this.options, true);
    this.chart.update(this.options, true, true);
  }
},
```

Internal series like the stock navigator are unaffected because one-to-one updating skips series flagged `isInternal`.

## Behavior changes

With this fix, the Python `options` dict becomes the single source of truth: one-to-one updating synchronizes not only `series` but also `xAxis`, `yAxis` (and `annotations`/`colorAxis` when those modules are loaded). Anything present on the chart but missing from `options` is removed on the next element update — including series, axes, or annotations added client-side via JavaScript. This is the intended declarative contract of the element.

**Known limitation:** server updates while a user is drilled into a chart (`extras=['drilldown']`) reset the drill view and can break drilling up, because the active drill series exists only client-side. The previous code happened to survive this case (when top-level series had `id`s), but `chart.update()` during drilldown is [shaky ground upstream](https://github.com/highcharts/highcharts/issues/7600) regardless. We document this rather than guarding against it; a guard that silently skips updates while drilled in would trade one surprise for another.

User-facing documentation for these semantics (single source of truth, recommending explicit series `id`s for dynamic add/remove) will be added to the `highchart` documentation page in the NiceGUI repository.

## Verification

Tested in a real browser (Playwright), standalone against the bundled Highcharts 12 as well as in a running NiceGUI app:

- the boiled-down toggle repro from #1 (6 toggles, chart always matches options)
- the test-page scenarios from #1: insert low/high, remove low, reset, clear — "insert low" no longer collapses the chart
- toggling series with explicit `id`s
- the original multi-select-with-chips repro: deselecting and reselecting a series three times keeps legend and chips in sync
- the same repro as `stockChart` with navigator: the internal "Navigator 1" series survives every update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

