### PR TITLE
Restore the browser default background of range selector inputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,4 +20,12 @@ ui.highchart({
     ],
 }, extras=['solid-gauge'])
 
+ui.highchart({
+    'title': False,
+    'rangeSelector': {'selected': 0},
+    'series': [
+        {'name': 'Gamma', 'data': [[1704067200000, 0.1], [1706745600000, 0.3], [1709251200000, 0.2]]},
+    ],
+}, type='stockChart', extras=['stock'])
+
 ui.run(port=7777)

--- a/nicegui_highcharts/highchart.js
+++ b/nicegui_highcharts/highchart.js
@@ -11,6 +11,17 @@ export default {
       await loadModule(extra);
     }
     convertDynamicProperties(this.options, true);
+    // Tailwind's CSS reset makes form controls transparent, so the native inputs Highcharts overlays on the
+    // range selector's date labels stop covering them. Highcharts merges inputStyle last into the input's
+    // inline style, so this beats the reset; default to the chart's background to stay readable when dark.
+    const background = this.options.chart?.backgroundColor ?? Highcharts.getOptions().chart?.backgroundColor;
+    this.options.rangeSelector = {
+      ...this.options.rangeSelector,
+      inputStyle: {
+        backgroundColor: Highcharts.color(background).rgba[3] === 1 ? background : "#fff",
+        ...this.options.rangeSelector?.inputStyle,
+      },
+    };
     this.options.plotOptions = this.options.plotOptions ?? {};
     this.options.plotOptions.series = this.options.plotOptions.series ?? {};
     this.options.plotOptions.series.point = this.options.plotOptions.series.point ?? {};

--- a/nicegui_highcharts/highchart.py
+++ b/nicegui_highcharts/highchart.py
@@ -1,3 +1,4 @@
+import weakref
 from collections.abc import Callable
 
 from nicegui import events, ui
@@ -9,9 +10,10 @@ from .events import (
     ChartPointDropEventArguments,
 )
 
+_clients_with_css: weakref.WeakSet = weakref.WeakSet()
+
 
 class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts': 'dist'}):
-    _css_added = False
 
     def __init__(self, options: dict, *,
                  type: str = 'chart', extras: list[str] = [],  # noqa: B006  # pylint: disable=redefined-builtin
@@ -46,12 +48,12 @@ class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts':
         :param on_point_drop: callback function that is called when a point is dropped
         """
         super().__init__()
-        if not Highchart._css_added:
-            Highchart._css_added = True
+        if self.client not in _clients_with_css:
+            _clients_with_css.add(self.client)
             # Tailwind's CSS reset makes form controls transparent, so the native inputs Highcharts puts over
             # the range selector's date labels stop covering them. Match the chart's own background instead of
             # the page's, so Highcharts' input text colour stays readable with or without dark mode.
-            ui.add_css('.highcharts-range-selector { background-color: #fff; }', shared=True)
+            ui.add_head_html('<style>@layer nicegui { .highcharts-range-selector { background-color: #fff; } }</style>')
         self._props['type'] = type
         self._props['options'] = options
         self._props['extras'] = extras

--- a/nicegui_highcharts/highchart.py
+++ b/nicegui_highcharts/highchart.py
@@ -1,4 +1,3 @@
-import weakref
 from collections.abc import Callable
 
 from nicegui import events, ui
@@ -9,8 +8,6 @@ from .events import (
     ChartPointDragStartEventArguments,
     ChartPointDropEventArguments,
 )
-
-_clients_with_css: weakref.WeakSet = weakref.WeakSet()
 
 
 class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts': 'dist'}):
@@ -48,12 +45,6 @@ class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts':
         :param on_point_drop: callback function that is called when a point is dropped
         """
         super().__init__()
-        if self.client not in _clients_with_css:
-            _clients_with_css.add(self.client)
-            # Tailwind's CSS reset makes form controls transparent, so the native inputs Highcharts puts over
-            # the range selector's date labels stop covering them. Match the chart's own background instead of
-            # the page's, so Highcharts' input text colour stays readable with or without dark mode.
-            ui.add_head_html('<style>@layer nicegui { .highcharts-range-selector { background-color: #fff; } }</style>')
         self._props['type'] = type
         self._props['options'] = options
         self._props['extras'] = extras

--- a/nicegui_highcharts/highchart.py
+++ b/nicegui_highcharts/highchart.py
@@ -9,10 +9,13 @@ from .events import (
     ChartPointDropEventArguments,
 )
 
+# Tailwind's CSS reset makes form controls transparent, so the native inputs Highcharts puts over the
+# range selector's date labels stop covering them. Match the chart's own background instead of the
+# page's, so Highcharts' input text colour stays readable with or without dark mode.
+ui.add_css('.highcharts-range-selector { background-color: #fff; }', shared=True)
 
-class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts': 'dist'},
-                # undo Tailwind's form control reset, so range selector inputs cover the date labels again
-                default_classes='[&_.highcharts-range-selector]:[background-color:revert]'):
+
+class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts': 'dist'}):
 
     def __init__(self, options: dict, *,
                  type: str = 'chart', extras: list[str] = [],  # noqa: B006  # pylint: disable=redefined-builtin

--- a/nicegui_highcharts/highchart.py
+++ b/nicegui_highcharts/highchart.py
@@ -10,7 +10,9 @@ from .events import (
 )
 
 
-class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts': 'dist'}):
+class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts': 'dist'},
+                # undo Tailwind's form control reset, so range selector inputs cover the date labels again
+                default_classes='[&_.highcharts-range-selector]:[background-color:revert]'):
 
     def __init__(self, options: dict, *,
                  type: str = 'chart', extras: list[str] = [],  # noqa: B006  # pylint: disable=redefined-builtin

--- a/nicegui_highcharts/highchart.py
+++ b/nicegui_highcharts/highchart.py
@@ -9,13 +9,9 @@ from .events import (
     ChartPointDropEventArguments,
 )
 
-# Tailwind's CSS reset makes form controls transparent, so the native inputs Highcharts puts over the
-# range selector's date labels stop covering them. Match the chart's own background instead of the
-# page's, so Highcharts' input text colour stays readable with or without dark mode.
-ui.add_css('.highcharts-range-selector { background-color: #fff; }', shared=True)
-
 
 class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts': 'dist'}):
+    _css_added = False
 
     def __init__(self, options: dict, *,
                  type: str = 'chart', extras: list[str] = [],  # noqa: B006  # pylint: disable=redefined-builtin
@@ -50,6 +46,12 @@ class Highchart(ui.element, component='highchart.js', esm={'nicegui-highcharts':
         :param on_point_drop: callback function that is called when a point is dropped
         """
         super().__init__()
+        if not Highchart._css_added:
+            Highchart._css_added = True
+            # Tailwind's CSS reset makes form controls transparent, so the native inputs Highcharts puts over
+            # the range selector's date labels stop covering them. Match the chart's own background instead of
+            # the page's, so Highcharts' input text colour stays readable with or without dark mode.
+            ui.add_css('.highcharts-range-selector { background-color: #fff; }', shared=True)
         self._props['type'] = type
         self._props['options'] = options
         self._props['extras'] = extras


### PR DESCRIPTION
*Posted by Claude Code on evnchn's behalf.*

**TL;DR:**

Fixes the range selector inputs going transparent under Tailwind v4's preflight, which sets `background-color: transparent` on every form control, so the native inputs Highcharts overlays on the date labels stop covering them.

Net diff against `main` is **+11 lines in `highchart.js`**, plus a `stockChart` repro in `main.py`. No Python change at all — `highchart.py` is byte-identical to `main`.

```js
const background = this.options.chart?.backgroundColor ?? Highcharts.getOptions().chart?.backgroundColor;
this.options.rangeSelector = {
  ...this.options.rangeSelector,
  inputStyle: {
    backgroundColor: Highcharts.color(background).rgba[3] === 1 ? background : "#fff",
    ...this.options.rangeSelector?.inputStyle,
  },
};
```

Highcharts merges `rangeSelector.inputStyle` last into the input's inline style, and inline beats the reset on every NiceGUI version — so no head HTML, no cascade layer, no per-client bookkeeping, no emitted JavaScript. The colour is the chart's own background rather than a constant, so a dark chart stays readable, and the app author's own `inputStyle` wins over both.

<details>
<summary><b>Why not a constant, and why not at module scope</b></summary>

Two variants that look right and are not:

**`Highcharts.setOptions(...)` at module scope is inert.** The `stock` module loads lazily in `mounted()`, i.e. after module scope, and composes with `extend(defaultOptions, {rangeSelector: <its own object>})` — a shallow assign that replaces the whole `rangeSelector` default and discards anything merged in earlier. Measures identical to no fix.

**Moving it after the module load works, but forces white on a dark chart.** Chart options merge deeply, so a theme setting only `inputStyle.color` (the dark-unica shape: `chart.backgroundColor: '#2a2a2b'` + `inputStyle.color: '#E0E0E3'`) does not displace a `backgroundColor` in the defaults — it merges alongside it, giving light text on a white box.

Computed `background-color` of the input after clicking the date box, Chromium, nicegui 3.16.0:

| | light | dark chart | dark via global `setOptions` | author's own `inputStyle.bg` | `styledMode` |
|---|---|---|---|---|---|
| `main` (no fix) | transparent | transparent | transparent | `#010203` | transparent |
| `setOptions` at module scope | transparent | transparent | transparent | `#010203` | transparent |
| `setOptions` after module load | `#fff` | `#fff` ❌ | `#fff` ❌ | `#010203` | transparent |
| a CSS rule in a cascade layer | `#fff` | `#fff` ❌ | `#fff` ❌ | `#010203` | `#fff` |
| **this branch** | `#fff` | `#2a2a2b` ✅ | `#2a2a2b` ✅ | `#010203` | transparent |

</details>

<details>
<summary><b>Verification</b></summary>

Every row measured in Chromium against the real package, at both ends of the declared `>=3.0.0` range (3.0.0 and 3.16.0), with identical results.

| gate | result |
|---|---|
| the matrix above | as shown, both versions |
| chart created on an already-connected client (button handler) | `#fff` ✅ |
| `options` setter → `update_chart` → `chart.update()` | `#fff` ✅ |
| range selector destroyed and re-drawn via `update` (`enabled` false → true) | `#fff` ✅, inputs verified to be **new** elements |
| `chart.backgroundColor: 'transparent'` | `#fff` ✅ — a transparent input would not cover the label |
| gradient / pattern / unset background | `#fff` ✅ |
| must-fail: revert the fix, same pages | transparent everywhere |
| `ruff` | All checks passed |
| `mypy` | Success, 4 source files |
| `main.py` boots and reproduces | ok on 3.0.0 and 3.16.0 |

`Highcharts.color(x).rgba[3] === 1` is what sorts the last three out: opaque colours return alpha `1`, while `'transparent'`, `'none'`, gradients and `undefined` all return `[null,null,null,null]`.

</details>

<details>
<summary><b>Residual risks and what is not tested</b></summary>

- **Chromium only.** Firefox and Safari untested; there is no CI on this repo.
- **`styledMode: true` stays transparent.** Highcharts skips inline input styling entirely in styled mode, so this fix is inert there and the input falls back to the author's own theme CSS — which is the styled-mode contract. The earlier CSS-rule approach painted it white, i.e. it violated that contract.
- **`inputStyle` is also merged into the SVG dateBox label's style.** `background-color` on that `<g>` has no visual effect (the fill lives on the inner `<rect>`), confirmed by inspecting the rendered element.
- **Not exercised:** `gantt`, `mapChart`.

</details>

---

*Changelog*
*2026-08-26 — body rewritten. The previous version described the per-client `<style>` + `@layer nicegui` approach, which was replaced in `91a682d`; its cascade tables and residual-risk notes no longer describe the code on this branch.*
